### PR TITLE
OpenID Connect endpoints discovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/alexdelprete/traefik-oidc-relying-party
 
 go 1.19
+
+require github.com/vexxhost/oidc-utils v0.0.0-20230227152836-375a8f8ce8c3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/vexxhost/oidc-utils v0.0.0-20230227152836-375a8f8ce8c3 h1:fgRiRZuseO64Ti3lSMGm6uw0hQHKP1/N4ZESVXn4zaw=
+github.com/vexxhost/oidc-utils v0.0.0-20230227152836-375a8f8ce8c3/go.mod h1:Q+KLGWyL2x3rQr0guOzC2LdRraKlx+pP6cQIYaI6GNU=


### PR DESCRIPTION
Replaced static endpoints with OpenID Connect discovery through 3rd-party library (https://github.com/vexxhost/oidc-utils).

This will allow the plugin to work seamlessly with all OpenID Providers that respect the OIDC specification.